### PR TITLE
Reset of the config.yml file and replacement of template variables

### DIFF
--- a/docs-book/config.yml
+++ b/docs-book/config.yml
@@ -1,12 +1,9 @@
 ---
 book_repo: docs-book
 layout_repo: docs-layout
-public_host: hello
-book_title: Crunchy PostgreSQL for PCF
 
 broken_link_exclusions: iefix|arrowhead
 repo_link_enabled: true
-feedback_enabled: true
 
 pcf_header: &local_pcf
   use_local_header: true
@@ -14,24 +11,16 @@ pcf_header: &local_pcf
   changelog_href: http://docs.pivotal.io/pivotalcf/pcf-release-notes/
   local_header_img: /images/cloud_rings.png
   local_header_title: Pivotal Cloud Foundry
+public_host: hello
 
 sections:
   - repository:
       name: docs-content
     directory: crunchy
-    subnav_template: crunchy_subnav.erb
+    subnav_template: crunchy_subnav.erb       
 
-template_variables:
-  book_title: Crunchy PostgreSQL for PCF
-  tile_version: 03.90510.107
-  release_date: January 24, 2018
-  service_name: postgresql-9.5-odb
-  service_name_long: Crunchy PostgreSQL for Pivotal Cloud Foundry (PCF) Tile
-  postgresql_version: 9.5.10
-  service_plans:
-    - small
-    - medium
-    - large
-    - extra-large
-  postgis_version: 2.3
+template_variables:                             # optional
 
+book_title: Partner Services Template
+book_repo: docs-book
+layout_repo: docs-layout

--- a/docs-content/_backup_information.erb
+++ b/docs-content/_backup_information.erb
@@ -1,4 +1,4 @@
-<%= vars.service_name_long -%> uses [pgBackrest](https://github.com/pgbackrest/pgbackrest) as a dedicated backup and archiving host.
+Crunchy PostgreSQL for Pivotal Cloud Foundry (PCF) Tile uses [pgBackrest](https://github.com/pgbackrest/pgbackrest) as a dedicated backup and archiving host.
 The tile comes pre-configured with nightly physical backups of the database server:
 
 | Day       | Backup Type | Time     |

--- a/docs-content/_creating_service.erb
+++ b/docs-content/_creating_service.erb
@@ -8,7 +8,7 @@ Ensure that the status of the service is <strong>create succeeded</strong> befor
 
 1. Create a service instance using the following command as a template:
 ```
-cf create-service <%= service_name -%> <%= service_plan -%> myService -c '
+cf create-service postgresql-9.5-odb small myService -c '
 {
         "db_name": "testdb",
         "db_username": "example",
@@ -28,4 +28,3 @@ cf restage <APP_NAME>
 ```
 
 The service will then be available for use within any bound application.
-

--- a/docs-content/_parameters.erb
+++ b/docs-content/_parameters.erb
@@ -22,7 +22,7 @@ Default is `UTF8`.
 in CIDR format that will be authorized to connect to the service database.
 * **monitoring**: Installs the monitoring extensions and Prometheus data store, true or false. Default is `false`.
 * **plr**: Enables PL/R extensions, true or false. Default is `false`.
-* **postgis**: Enable PostGIS <%= vars.postgis_version -%> extensions,
+* **postgis**: Enable PostGIS 2.3 extensions,
 true or false. Extensions include `postgis`, `postgis_tiger_geocoder`,
 `postgis_topology`, and `fuzzystrmatch`.
 Default is `false`.

--- a/docs-content/_product_snapshot.erb
+++ b/docs-content/_product_snapshot.erb
@@ -6,15 +6,15 @@ Crunchy PostgreSQL for PCF:
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td><%= vars.tile_version -%></td>
+        <td>03.90510.107</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td><%= vars.release_date -%></td>
+        <td>January 24, 2018</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>PostgreSQL v<%= vars.postgresql_version -%></td>
+        <td>PostgreSQL v9.5.10</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
@@ -29,4 +29,3 @@ Crunchy PostgreSQL for PCF:
         <td>AWS, Azure, GCP, OpenStack, and vSphere</td>
     </tr>
 </table>
-

--- a/docs-content/feature-overview.html.md.erb
+++ b/docs-content/feature-overview.html.md.erb
@@ -14,12 +14,10 @@ When deploying the service, operators have the opportunity to tune these plans f
 
 The plans that are included are as follows:
 
-<ul>
-  <li>small</li>
-  <li>medium</li>
-  <li>large</li>
-  <li>extra-large</li>
-</ul>
+- small
+- medium
+- large
+- extra-large
 
 ###<a id='suggested_plan'></a> Suggested Plan Configuration
 

--- a/docs-content/feature-overview.html.md.erb
+++ b/docs-content/feature-overview.html.md.erb
@@ -3,20 +3,23 @@ title: Feature Overview of Crunchy PostgreSQL for PCF
 owner: Crunchy Data
 ---
 
-This topic describes the features of <%= vars.service_name_long -%>.
+This topic describes the features of Crunchy PostgreSQL for Pivotal Cloud Foundry (PCF) Tile.
 
 ##<a id ="plans"></a> Plans
 
-The <%= vars.service_name_long -%> offers several out-of-the-box (configurable) plans.
+The Crunchy PostgreSQL for Pivotal Cloud Foundry (PCF) Tile offers several out-of-the-box (configurable) plans.
 When deploying the service, operators have the opportunity to tune these plans for the needs of the environment.
 
 ###<a id='plansize'></a> Plan Sizes
 
 The plans that are included are as follows:
 
-<% vars.service_plans.each do |service| -%>
-- <%= service %>
-<% end -%>
+<ul>
+  <li>small</li>
+  <li>medium</li>
+  <li>large</li>
+  <li>extra-large</li>
+</ul>
 
 ###<a id='suggested_plan'></a> Suggested Plan Configuration
 

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -12,7 +12,7 @@ to use Crunchy PostgreSQL databases with their apps.
 Crunchy PostgreSQL For PCF includes the following key features:
 
 * On-Demand single-tenant service
-* Crunchy PostgreSQL v<%= vars.postgresql_version -%> and PostGIS v<%= vars.postgis_version %>
+* Crunchy PostgreSQL v9.5.10 and PostGIS v2.3
 * Primary/replica PostgreSQL architecture
 * Load-balanced read replicas
 * Automated backups with pgBackrest

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -3,11 +3,11 @@ title: Installing and Configuring Crunchy PostgreSQL for PCF
 owner: Crunchy Data
 ---
 
-This topic describes how to install and configure <%= vars.service_name_long -%>.
+This topic describes how to install and configure Crunchy PostgreSQL for Pivotal Cloud Foundry (PCF) Tile.
 
 ##<a id='import'></a> Import the Tile to Ops Manager
 
-1. Download the <%= vars.service_name_long -%> file from [Pivotal Network](https://network.pivotal.io/products/crunchy-postgresql/).
+1. Download the Crunchy PostgreSQL for Pivotal Cloud Foundry (PCF) Tile file from [Pivotal Network](https://network.pivotal.io/products/crunchy-postgresql/).
 
 1. Navigate to the Ops Manager Installation Dashboard and click
 **Import a Product** to upload the product file.

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -3,7 +3,7 @@ title: Crunchy PostgreSQL for PCF Release Notes
 owner: Crunchy Data
 ---
 
-This topic provides release notes for <%= vars.service_name_long -%>.
+This topic provides release notes for Crunchy PostgreSQL for Pivotal Cloud Foundry (PCF) Tile.
 
 ##<a id="03.090510.107"></a> v03.090510.107
 <%= partial('release_03.090510.107') -%>

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -21,12 +21,10 @@ This service includes:
 ###<a id='service-info'></a> PostgreSQL Plans
 The `postgresql-9.5-odb` service comes with several plans:
 
-<ul>
-  <li>small</li>
-  <li>medium</li>
-  <li>large</li>
-  <li>extra-large</li>
-</ul>
+- small
+- medium
+- large
+- extra-large
 
 Each plan corresponds to different server size set up by the operator when the
 service was deployed.

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -3,13 +3,13 @@ title: Using Crunchy PostgreSQL for PCF
 owner: Crunchy Data
 ---
 
-This topic describes how to use <%= vars.service_name_long -%>.
+This topic describes how to use Crunchy PostgreSQL for Pivotal Cloud Foundry (PCF) Tile.
 
 ##<a id='using'></a> Crunchy PostgreSQL Service
-<%= vars.service_name_long -%> is an on-demand, single-tenant PostgreSQL database service.
+Crunchy PostgreSQL for Pivotal Cloud Foundry (PCF) Tile is an on-demand, single-tenant PostgreSQL database service.
 Crunchy PostgreSQL comes with one service:
 
-* <%= vars.service_name %>
+* postgresql-9.5-odb
 
 This service includes:
 
@@ -19,11 +19,14 @@ This service includes:
 * Consul cluster
 
 ###<a id='service-info'></a> PostgreSQL Plans
-The `<%= vars.service_name -%>` service comes with several plans:
+The `postgresql-9.5-odb` service comes with several plans:
 
-<% vars.service_plans.each do |service| -%>
-- <%= service %>
-<% end -%>
+<ul>
+  <li>small</li>
+  <li>medium</li>
+  <li>large</li>
+  <li>extra-large</li>
+</ul>
 
 Each plan corresponds to different server size set up by the operator when the
 service was deployed.
@@ -38,13 +41,7 @@ Review each plan offering and choose the correct database size for the applicati
 
 ###<a id='create-new'></a> Creating a New Service
 <%=
-partial(
-    :creating_service,
-    :locals => {
-        :service_name => vars.service_name,
-        :service_plan => vars.service_plans[0]
-    }
-)
+partial('creating_service')
 -%>
 
 ##<a id='integration'></a> Integrating Applications


### PR DESCRIPTION
This PR contains the reset of the config.yml file to its state in commit 210bd345c37178dae5e646bd636a4718efd3892f and replacing the template variables with the actuals. 

Once this PR is approved we will execute another PR request to the parent repo and work with Pivotal to push it up. 

**Added**
None

**Removed**
- Removed the template variables from config.yml by resetting to the previous version

**Notes**
The reason for this is because Pivotal has a centralized config.yml file that they use for all customers. Modification of the config.yml is not allowed. 
I only committed the docs-content changes as well as the config.yml reset for testing. 

**Testing**
- Follow instructions documented in the Readme to serve docs locally
- Review resulting page on localhost:4567 for any factual, typographical, or grammatical errors.